### PR TITLE
Introduce the openjfx-build repo

### DIFF
--- a/docs/ios/javafx.md
+++ b/docs/ios/javafx.md
@@ -24,7 +24,7 @@ we will first build the OpenJFX code using the OpenJDK build system.
 
 Although, in theory, we only need to build OpenJFX for iOS and Android, using the same approach for 
 building OpenJFX on desktop platforms offers benefits. Work of this is ongoing in the
-https://github.com/organizations/openjdk-mobile repository
+https://github.com/openjdk-mobile/openjfx-build repository
 
 
 

--- a/docs/ios/javafx.md
+++ b/docs/ios/javafx.md
@@ -14,3 +14,17 @@ This track enables full **JavaFX applications** to run as native iOS apps.
 - Simple JavaFX scene renders on iOS and handles touch input.
 - App lifecycle (background/foreground/rotation) works correctly.
 - Packaging produces a deployable iOS app that passes basic stability and UI responsiveness tests.
+
+## Approach
+
+Both OpenJDK and OpenJFX have several requirements for the underlying operating system and environment,
+and both rely on a variety of tools (including compilers and linkers) to build artifacts.
+To minimize overlap and increase consistency, we aim to leverage the same tools. Therefore,
+we will first build the OpenJFX code using the OpenJDK build system.
+
+Although, in theory, we only need to build OpenJFX for iOS and Android, using the same approach for 
+building OpenJFX on desktop platforms offers benefits. Work of this is ongoing in the
+https://github.com/organizations/openjdk-mobile repository
+
+
+


### PR DESCRIPTION
This PR explains the first step we need to do to get HelloFX running on iOS, and it introduces the new openjfx-build repo